### PR TITLE
Refactor getLine to return TextLines/Rope

### DIFF
--- a/src/Data/Text/Lines/Internal.hs
+++ b/src/Data/Text/Lines/Internal.hs
@@ -253,17 +253,17 @@ splitAtLine k = splitAtPosition (Position k 0)
 -- ["fя𐀀","☺bar","",""]
 --
 -- @since 0.3
-getLine :: Word -> TextLines -> Text
+getLine :: Word -> TextLines -> TextLines
 getLine line (TextLines t@(Text arr off len) nls)
   | intToWord (U.length nls) < line = mempty
   | otherwise =
     let lineIdx = wordToInt line
-    in case (nls U.!? (lineIdx - 1), nls U.!? lineIdx) of
-      (Nothing, Nothing) -> t
-      (Nothing, Just endNl) -> Text arr off (endNl - off) -- branch triggered by `getLine 0 "a\n"`
-      (Just startNl, Nothing) -> Text arr (startNl + 1) (len + off - startNl - 1)
-      (Just startNl, Just endNl) -> Text arr (startNl + 1) (endNl - startNl - 1)
-
+        tNew = case (nls U.!? (lineIdx - 1), nls U.!? lineIdx) of
+          (Nothing, Nothing) -> t
+          (Nothing, Just endNl) -> Text arr off (endNl - off) -- branch triggered by `getLine 0 "a\n"`
+          (Just startNl, Nothing) -> Text arr (startNl + 1) (len + off - startNl - 1)
+          (Just startNl, Just endNl) -> Text arr (startNl + 1) (endNl - startNl - 1)
+    in TextLines tNew mempty
 -------------------------------------------------------------------------------
 -- Unicode code points
 

--- a/src/Data/Text/Mixed/Rope.hs
+++ b/src/Data/Text/Mixed/Rope.hs
@@ -567,7 +567,7 @@ utf16SplitAtPosition (Utf16.Position l c) rp = do
   Just (beforeLine <> beforeColumn, afterColumn)
 
 -- | Get a line by its 0-based index.
--- Returns @""@ if the index is out of bounds.
+-- Returns empty Rope if the index is out of bounds.
 -- The result doesn't contain @\\n@ characters.
 --
 -- >>> :set -XOverloadedStrings
@@ -575,9 +575,9 @@ utf16SplitAtPosition (Utf16.Position l c) rp = do
 -- ["foo","bar","😊😊",""]
 --
 -- @since 0.3
-getLine :: Word -> Rope -> Text
+getLine :: Word -> Rope -> Rope
 getLine lineIdx rp =
-  case T.unsnoc firstLine of
+  fromText $ case T.unsnoc firstLine of
     Just (firstLineInit, '\n') -> firstLineInit
     _ -> firstLine
   where

--- a/src/Data/Text/Rope.hs
+++ b/src/Data/Text/Rope.hs
@@ -391,7 +391,7 @@ splitAtPosition (Position l c) rp = (beforeLine <> beforeColumn, afterColumn)
     (beforeColumn, afterColumn) = splitAt c afterLine
 
 -- | Get a line by its 0-based index.
--- Returns @""@ if the index is out of bounds.
+-- Returns empty Rope if the index is out of bounds.
 -- The result doesn't contain @\\n@ characters.
 --
 -- >>> :set -XOverloadedStrings
@@ -399,9 +399,9 @@ splitAtPosition (Position l c) rp = (beforeLine <> beforeColumn, afterColumn)
 -- ["foo","bar","😊😊",""]
 --
 -- @since 0.3
-getLine :: Word -> Rope -> Text
+getLine :: Word -> Rope -> Rope
 getLine lineIdx rp =
-  case T.unsnoc firstLine of
+  fromText $ case T.unsnoc firstLine of
     Just (firstLineInit, '\n') -> firstLineInit
     _ -> firstLine
   where

--- a/src/Data/Text/Utf16/Rope.hs
+++ b/src/Data/Text/Utf16/Rope.hs
@@ -394,7 +394,7 @@ splitAtPosition (Position l c) rp = do
   Just (beforeLine <> beforeColumn, afterColumn)
 
 -- | Get a line by its 0-based index.
--- Returns @""@ if the index is out of bounds.
+-- Returns empty Rope if the index is out of bounds.
 -- The result doesn't contain @\\n@ characters.
 --
 -- >>> :set -XOverloadedStrings
@@ -402,9 +402,9 @@ splitAtPosition (Position l c) rp = do
 -- ["foo","bar","😊😊",""]
 --
 -- @since 0.3
-getLine :: Word -> Rope -> Text
+getLine :: Word -> Rope -> Rope
 getLine lineIdx rp =
-  case T.unsnoc firstLine of
+  fromText $ case T.unsnoc firstLine of
     Just (firstLineInit, '\n') -> firstLineInit
     _ -> firstLine
   where

--- a/src/Data/Text/Utf8/Rope.hs
+++ b/src/Data/Text/Utf8/Rope.hs
@@ -395,7 +395,7 @@ splitAtPosition (Position l c) rp = do
   Just (beforeLine <> beforeColumn, afterColumn)
 
 -- | Get a line by its 0-based index.
--- Returns @""@ if the index is out of bounds.
+-- Returns empty Rope if the index is out of bounds.
 -- The result doesn't contain @\\n@ characters.
 --
 -- >>> :set -XOverloadedStrings
@@ -403,9 +403,9 @@ splitAtPosition (Position l c) rp = do
 -- ["foo","bar","😊😊",""]
 --
 -- @since 0.3
-getLine :: Word -> Rope -> Text
+getLine :: Word -> Rope -> Rope
 getLine lineIdx rp =
-  case T.unsnoc firstLine of
+  fromText $ case T.unsnoc firstLine of
     Just (firstLineInit, '\n') -> firstLineInit
     _ -> firstLine
   where

--- a/test/CharLines.hs
+++ b/test/CharLines.hs
@@ -105,7 +105,7 @@ testSuite = testGroup "Char Lines"
 
   , testProperty "forall i in bounds: getLine i x == lines x !! i" $
     \x -> let lns = lines x in
-      conjoin $ zipWith (\idx ln -> getLine idx x === ln) [0..] lns
+      conjoin $ zipWith (\idx ln -> toText (getLine idx x) === ln) [0..] lns
   , testProperty "forall i out of bounds: getLine i x == mempty" $
     \x (Positive offset) ->
       let maxIdx = L.genericLength (lines x) - 1

--- a/test/CharRope.hs
+++ b/test/CharRope.hs
@@ -53,7 +53,7 @@ testSuite = testGroup "Char Rope"
 
   , testProperty "forall i in bounds: getLine i x == lines x !! i" $
     \x -> let lns = Rope.lines x in
-      conjoin $ L.zipWith (\idx ln -> Rope.getLine idx x === ln) [0..] lns
+      conjoin $ L.zipWith (\idx ln -> Rope.toText (Rope.getLine idx x) === ln) [0..] lns
   , testProperty "forall i out of bounds: getLine i x == mempty" $
     \x (Positive offset) ->
       let maxIdx = L.genericLength (Rope.lines x) - 1

--- a/test/MixedRope.hs
+++ b/test/MixedRope.hs
@@ -111,7 +111,7 @@ testSuite = testGroup "Utf16 Mixed"
 
   , testProperty "forall i in bounds: getLine i x == lines x !! i" $
     \x -> let lns = Mixed.lines x in
-      conjoin $ L.zipWith (\idx ln -> Mixed.getLine idx x === ln) [0..] lns
+      conjoin $ L.zipWith (\idx ln -> Mixed.toText (Mixed.getLine idx x) === ln) [0..] lns
   , testProperty "forall i out of bounds: getLine i x == mempty" $
     \x (Positive offset) ->
       let maxIdx = L.genericLength (Mixed.lines x) - 1

--- a/test/Utf16Rope.hs
+++ b/test/Utf16Rope.hs
@@ -71,7 +71,7 @@ testSuite = testGroup "Utf16 Rope"
 
   , testProperty "forall i in bounds: getLine i x == lines x !! i" $
     \x -> let lns = Rope.lines x in
-      conjoin $ L.zipWith (\idx ln -> Rope.getLine idx x === ln) [0..] lns
+      conjoin $ L.zipWith (\idx ln -> Rope.toText (Rope.getLine idx x) === ln) [0..] lns
   , testProperty "forall i out of bounds: getLine i x == mempty" $
     \x (Positive offset) ->
       let maxIdx = L.genericLength (Rope.lines x) - 1

--- a/test/Utf8Rope.hs
+++ b/test/Utf8Rope.hs
@@ -58,7 +58,7 @@ testSuite = testGroup "Utf8 Rope"
 
   , testProperty "forall i in bounds: getLine i x == lines x !! i" $
     \x -> let lns = Rope.lines x in
-      conjoin $ L.zipWith (\idx ln -> Rope.getLine idx x === ln) [0..] lns
+      conjoin $ L.zipWith (\idx ln -> Rope.toText (Rope.getLine idx x) === ln) [0..] lns
   , testProperty "forall i out of bounds: getLine i x == mempty" $
     \x (Positive offset) ->
       let maxIdx = L.genericLength (Rope.lines x) - 1


### PR DESCRIPTION
As @michaelpj pointed out, for many use-cases it might be preferable if getLine stays within the world of Ropes, to allow for further processing (an example of this is in [lsp](https://github.com/haskell/lsp/blob/dfdff1380b747dcde47d497cee8772775a963957/lsp/src/Language/LSP/VFS.hs#L404-L411) and similar, currently incorrect usage of getLine-like functionality mentioned in this comment in hls: https://github.com/haskell/haskell-language-server/pull/4303#issuecomment-2156657031

The initial impl. ini this PR might not be ideal, because its complexity is linear in the length of line being wrapped. But let me open a PR to get initial feedback.
